### PR TITLE
Fixed Additional information button bug with headers containing withheld information.

### DIFF
--- a/docker/service/src/main/java/uk/nhs/adaptors/scr/models/GpSummary.java
+++ b/docker/service/src/main/java/uk/nhs/adaptors/scr/models/GpSummary.java
@@ -8,6 +8,8 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Property;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.springframework.stereotype.Component;
 import uk.nhs.adaptors.scr.exceptions.FhirMappingException;
 import uk.nhs.adaptors.scr.exceptions.FhirValidationException;
@@ -124,6 +126,43 @@ public class GpSummary {
         return gpSummary;
     }
 
+    /**
+     * Determination of withheld information is done by parsing the html information attached to the header.
+     * Those that have information to display will have elements other than the ones specified below.
+     * This is done like this because there is not always a structured object to accompany the headers.
+     */
+    public static boolean hasInformationThatIsNotWithheld(XhtmlNode html) {
+        // A list of common HTML element IDs that any withheld information will contain.
+        ArrayList<String> commonHtmlIds = new ArrayList<String>();
+        commonHtmlIds.add("Disclaimer");
+        commonHtmlIds.add("CreateTime");
+        commonHtmlIds.add("WithheldCREItemsHeaderStatement");
+        commonHtmlIds.add("WithheldCREItemsStatement");
+        commonHtmlIds.add("Author");
+        commonHtmlIds.add("Practice");
+        commonHtmlIds.add("SendTime");
+
+
+        for (XhtmlNode childNode:html.getChildNodes().get(0).getChildNodes()) {
+
+            /**
+             * Edge case: Some headers will not have html information attached to it.
+             * It is assumed that they will be filtered out later down the line as they
+             * will not be additional information headers.
+             */
+            if (childNode.getChildNodes().isEmpty()) {
+                return false;
+            }
+
+            // Any ids other than the common ones mean that information to display is present.
+            if (!commonHtmlIds.contains(childNode.getAttribute("id").toString())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static ImmutablePair<Boolean, Map<String, String>> isBundleWithAdditionalInformation(Bundle bundle) {
         //A list of all the additional headers for comparison that will trigger third party correspondence.
         Map<String, String> additionalInformationHeaders = new HashMap() {
@@ -151,7 +190,7 @@ public class GpSummary {
 
         Property gpList = bundle.getEntry().get(0).getResource().getChildByName("section"); //entries stored in this section
 
-        //A list that will contain all headers present in the bundle, no matter if they're additional information or not.
+        // A list that will contain all headers present in the bundle, no matter if they're additional information or not.
         ArrayList<String> headerList = new ArrayList<String>();
 
         gpList.getValues().forEach(gp -> {
@@ -160,11 +199,17 @@ public class GpSummary {
             Base codingValue = coding.getValues().get(0);
 
             Base header = codingValue.getChildByName("code").getValues().get(0); //header extracted in this variable
+            XhtmlNode html = ((Composition.SectionComponent) gp).getText().getDiv();
 
-            headerList.add(((CodeType) header).getCode());
+            // Check if there is any pertinent information to display attached to the header.
+            // Withheld information is not to be displayed.
+            if (hasInformationThatIsNotWithheld(html)) {
+                headerList.add(((CodeType) header).getCode());
+            }
         });
 
-        //assign all the headers that are additional information and present in the bundle. Removes duplicates, if any.
+
+        // Assign all the headers that are additional information and present in the bundle. Removes duplicates, if any.
         Map<String, String> additionalInformationHeadersPresent = new HashMap();
         additionalInformationHeaders.entrySet().stream()
                 .filter(headerEntry -> headerList.contains(headerEntry.getValue()))
@@ -173,8 +218,6 @@ public class GpSummary {
         if (additionalInformationHeadersPresent.size() > 0) {
             return new ImmutablePair<>(true, additionalInformationHeadersPresent);
         }
-
-        System.out.println("No additional information headers found!");
 
         return new ImmutablePair<>(false, additionalInformationHeadersPresent);
     }

--- a/docker/service/src/test/java/uk/nhs/adaptors/scr/models/GpSummaryTest.java
+++ b/docker/service/src/test/java/uk/nhs/adaptors/scr/models/GpSummaryTest.java
@@ -72,6 +72,42 @@ public class GpSummaryTest {
     }
 
     /**
+     * Given a supplied bundle with additional information where the same header contains withheld information AND
+     * information to display, third party correspondence should be returned.
+     */
+    @Test
+    public void When_MappingBundleWithWithheldInformationAndAdditionalInformation_Expect_ThirdPartyCorrespondence() {
+        ArrayList<String> expectedRecordTypes = new ArrayList<String>() {
+            {
+                add("Personal Preferences");
+            }
+        };
+
+        var jsonFile = readResourceFile(String.format(BUNDLE_RESOURCE_DIRECTORY + "/%s.json",
+                "withheld-information-and-additional"));
+        var bundle = fhirParser.parseResource(jsonFile, Bundle.class);
+        var result = GpSummary.fromBundle(bundle, NHSD_ASID);
+
+        assertThat(result.getThirdPartyCorrespondences().stream().count()).isEqualTo(1);
+        assertThirdPartyCorrespondenceText(result, expectedRecordTypes);
+    }
+
+    /**
+     * Given a supplied bundle with additional information that is withheld,
+     * third party correspondence section should not be found.
+     */
+    @Test
+    public void When_MappingBundleWithWithheldInformation_Expect_NoThirdPartyCorrespondence() {
+
+        var jsonFile = readResourceFile(String.format(BUNDLE_RESOURCE_DIRECTORY + "/%s.json",
+                "withheld-information"));
+        var bundle = fhirParser.parseResource(jsonFile, Bundle.class);
+        var result = GpSummary.fromBundle(bundle, NHSD_ASID);
+
+        assertThat(result.getThirdPartyCorrespondences().stream().count()).isEqualTo(0);
+    }
+
+    /**
      * Given a supplied bundle multiple treatments and risks to patient, third party correspondence section should be found.
      */
     @Test

--- a/docker/service/src/test/resources/gp_summary/from/fhir/additionalinfo/withheld-information-and-additional.json
+++ b/docker/service/src/test/resources/gp_summary/from/fhir/additionalinfo/withheld-information-and-additional.json
@@ -1,0 +1,197 @@
+{
+    "resourceType": "Bundle",
+    "id": "0F21CFC5-AC13-4A16-A8FE-5659DEC2B316",
+    "identifier": {
+        "system": "https://tools.ietf.org/html/rfc4122",
+        "value": "F65DF67B-F0D7-11ED-A34D-F40343488B16"
+    },
+    "type": "document",
+    "timestamp": "2023-05-12T15:16:26+00:00",
+    "entry": [
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Composition/4AB02CD0-AE61-11E7-A4D0-11E81EF36166",
+            "resource": {
+                "resourceType": "Composition",
+                "id": "4AB02CD0-AE61-11E7-A4D0-11E81EF36166",
+                "meta": {
+                    "lastUpdated": "2017-10-11T09:50+00:00"
+                },
+                "identifier": {
+                    "system": "https://tools.ietf.org/html/rfc4122",
+                    "value": "4AB02CD0-AE61-11E7-A4D0-11E81EF36166"
+                },
+                "status": "final",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "196981000000101",
+                            "display": "General Practice Summary"
+                        }
+                    ]
+                },
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "163171000000105",
+                                "display": "Care Professional Documentation"
+                            }
+                        ]
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/6B6EF256-F6D2-49DB-A542-A40E7D7B8857"
+                },
+                "date": "2017-10-11T09:50:54+00:00",
+                "author": [
+                    {
+                        "reference": "PractitionerRole/A106D415-2361-4E05-8386-6BBE26D8A050"
+                    }
+                ],
+                "relatesTo": [
+                    {
+                        "code": "replaces",
+                        "targetIdentifier": {
+                            "value": "74706381-ADC3-11E7-8221-1534459FDFDB"
+                        }
+                    }
+                ],
+                "section": [
+                    {
+                        "title": "General Practice Summary",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "Title"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h3 id=\"Disclaimer\">Sourced from the patient's General Practice record. This summary may not include all the information pertinent to this patient.</h3><p id=\"CreateTime\">Summary created: 11 Oct 2017 09:50</p><p id=\"WithheldCREItemsHeaderStatement\" class=\"HighlightedStatement\">One or more entries have been deliberately withheld from this GP Summary.</p><p id=\"Author\">Created by: RADFORD, Michelle (Mrs)</p><p id=\"Practice\">DR DK NANDI'S PRACTICE, 342 Troy Road, Horsforth, Leeds LS18 5TN</p></div>"
+                        }
+                    },
+                    {
+                        "title": "Allergies and Adverse Reactions",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "AllergiesHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's allergies and adverse reactions\" id=\"Allergies\"><thead><tr><th>Date</th><th>Description</th><th>Certainty</th><th>Severity</th><th>Supporting Information</th></tr></thead><tbody><tr class=\"oddRow\"><td>23 Feb 2017</td><td>Sensitivity to ACICLOVIR</td><td/><td/><td/></tr><tr class=\"evenRow\"><td>23 Feb 2017</td><td>Sensitivity to FAMCICLOVIR</td><td/><td/><td/></tr><tr class=\"oddRow\"><td>23 Feb 2017</td><td>Sensitivity to ISOFLURANE</td><td/><td/><td/></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Acute Medications (For the 12 month period 11 Oct 2016 to 11 Oct 2017)",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "AcuteMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's acute medications.\" id=\"AcuteMeds\"><thead><tr><th>Type</th><th>Date</th><th>Medication Item</th><th>Dosage Instructions</th><th>Quantity</th></tr></thead><tbody><tr class=\"oddRow\"><td>Acute Medication</td><td>Prescribed: 23 Feb 2017</td><td>Chorionic gonadotrophin 5,000unit powder and solvent for solution for injection ampoules</td><td>use as directed</td><td>1 ampoule</td></tr><tr class=\"oddRow\"><td colspan=\"2\"/><td>Supporting Information: {Batch Number} {Pack Size}</td><td colspan=\"2\"/></tr><tr class=\"evenRow\"><td>Acute Medication</td><td>Prescribed: 23 Feb 2017</td><td>Cyclopentolate 1% eye drops</td><td>one drop as directed</td><td>5 ml</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Current Repeat Medications",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "RepeatMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's current repeat medications.\" id=\"RepeatMeds\"><tbody><tr><td>No relevant information available for this category</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Discontinued Repeat Medications (For the 6 month period 11 Apr 2017 to 11 Oct 2017)",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "DiscRepeatMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's past repeat medications.\" id=\"DiscRepeatMeds\"><tbody><tr><td>No relevant information available for this category</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Personal Preferences",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "PreferencesHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p id=\"WithheldCREItemsHeaderStatement\" class=\"HighlightedStatement\">One or more entries have been deliberately withheld from this GP Summary.</p><table id=\"Preferences\"><thead><tr><th>Date</th><th>Description</th><th>Value</th><th>Supporting Information</th></tr></thead><tbody><tr class=\"oddRow\"><td>10 Oct 2017</td><td>Preferred place of death: hospice</td><td/><td>test 3</td></tr><tr class=\"evenRow\"><td>23 Feb 2017</td><td>Express consent for core and additional SCR dataset upload</td><td/><td/></tr></tbody></table><p id=\"SendTime\">Summary Sent: 11 Oct 2017 09:50</p></div>"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/PractitionerRole/A106D415-2361-4E05-8386-6BBE26D8A050",
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "A106D415-2361-4E05-8386-6BBE26D8A050",
+                "identifier": [
+                    {
+                        "system": "http://fhir.nhs.net/Id/sds-role-profile-id",
+                        "value": "103292576980"
+                    }
+                ],
+                "practitioner": {
+                    "reference": "Practitioner/76FC7363-4422-4872-AB72-E39ACEF23C7E"
+                }
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Practitioner/76FC7363-4422-4872-AB72-E39ACEF23C7E",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "76FC7363-4422-4872-AB72-E39ACEF23C7E",
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                        "value": "103267400988"
+                    }
+                ],
+                "name": [
+                    {
+                        "text": "MICHELLEMrsRADFORD"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Patient/6B6EF256-F6D2-49DB-A542-A40E7D7B8857",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "6B6EF256-F6D2-49DB-A542-A40E7D7B8857",
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "5900247767"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/docker/service/src/test/resources/gp_summary/from/fhir/additionalinfo/withheld-information.json
+++ b/docker/service/src/test/resources/gp_summary/from/fhir/additionalinfo/withheld-information.json
@@ -1,0 +1,197 @@
+{
+    "resourceType": "Bundle",
+    "id": "0F21CFC5-AC13-4A16-A8FE-5659DEC2B316",
+    "identifier": {
+        "system": "https://tools.ietf.org/html/rfc4122",
+        "value": "F65DF67B-F0D7-11ED-A34D-F40343488B16"
+    },
+    "type": "document",
+    "timestamp": "2023-05-12T15:16:26+00:00",
+    "entry": [
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Composition/4AB02CD0-AE61-11E7-A4D0-11E81EF36166",
+            "resource": {
+                "resourceType": "Composition",
+                "id": "4AB02CD0-AE61-11E7-A4D0-11E81EF36166",
+                "meta": {
+                    "lastUpdated": "2017-10-11T09:50+00:00"
+                },
+                "identifier": {
+                    "system": "https://tools.ietf.org/html/rfc4122",
+                    "value": "4AB02CD0-AE61-11E7-A4D0-11E81EF36166"
+                },
+                "status": "final",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "196981000000101",
+                            "display": "General Practice Summary"
+                        }
+                    ]
+                },
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "163171000000105",
+                                "display": "Care Professional Documentation"
+                            }
+                        ]
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/6B6EF256-F6D2-49DB-A542-A40E7D7B8857"
+                },
+                "date": "2017-10-11T09:50:54+00:00",
+                "author": [
+                    {
+                        "reference": "PractitionerRole/A106D415-2361-4E05-8386-6BBE26D8A050"
+                    }
+                ],
+                "relatesTo": [
+                    {
+                        "code": "replaces",
+                        "targetIdentifier": {
+                            "value": "74706381-ADC3-11E7-8221-1534459FDFDB"
+                        }
+                    }
+                ],
+                "section": [
+                    {
+                        "title": "General Practice Summary",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "Title"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h3 id=\"Disclaimer\">Sourced from the patient's General Practice record. This summary may not include all the information pertinent to this patient.</h3><p id=\"CreateTime\">Summary created: 11 Oct 2017 09:50</p><p id=\"WithheldCREItemsHeaderStatement\" class=\"HighlightedStatement\">One or more entries have been deliberately withheld from this GP Summary.</p><p id=\"Author\">Created by: RADFORD, Michelle (Mrs)</p><p id=\"Practice\">DR DK NANDI'S PRACTICE, 342 Troy Road, Horsforth, Leeds LS18 5TN</p></div>"
+                        }
+                    },
+                    {
+                        "title": "Allergies and Adverse Reactions",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "AllergiesHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's allergies and adverse reactions\" id=\"Allergies\"><thead><tr><th>Date</th><th>Description</th><th>Certainty</th><th>Severity</th><th>Supporting Information</th></tr></thead><tbody><tr class=\"oddRow\"><td>23 Feb 2017</td><td>Sensitivity to ACICLOVIR</td><td/><td/><td/></tr><tr class=\"evenRow\"><td>23 Feb 2017</td><td>Sensitivity to FAMCICLOVIR</td><td/><td/><td/></tr><tr class=\"oddRow\"><td>23 Feb 2017</td><td>Sensitivity to ISOFLURANE</td><td/><td/><td/></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Acute Medications (For the 12 month period 11 Oct 2016 to 11 Oct 2017)",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "AcuteMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's acute medications.\" id=\"AcuteMeds\"><thead><tr><th>Type</th><th>Date</th><th>Medication Item</th><th>Dosage Instructions</th><th>Quantity</th></tr></thead><tbody><tr class=\"oddRow\"><td>Acute Medication</td><td>Prescribed: 23 Feb 2017</td><td>Chorionic gonadotrophin 5,000unit powder and solvent for solution for injection ampoules</td><td>use as directed</td><td>1 ampoule</td></tr><tr class=\"oddRow\"><td colspan=\"2\"/><td>Supporting Information: {Batch Number} {Pack Size}</td><td colspan=\"2\"/></tr><tr class=\"evenRow\"><td>Acute Medication</td><td>Prescribed: 23 Feb 2017</td><td>Cyclopentolate 1% eye drops</td><td>one drop as directed</td><td>5 ml</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Current Repeat Medications",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "RepeatMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's current repeat medications.\" id=\"RepeatMeds\"><tbody><tr><td>No relevant information available for this category</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Discontinued Repeat Medications (For the 6 month period 11 Apr 2017 to 11 Oct 2017)",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "DiscRepeatMedsHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table summary=\"This table includes information about this patient's past repeat medications.\" id=\"DiscRepeatMeds\"><tbody><tr><td>No relevant information available for this category</td></tr></tbody></table></div>"
+                        }
+                    },
+                    {
+                        "title": "Personal Preferences",
+                        "code": {
+                            "coding": [
+                                {
+                                    "code": "PreferencesHeader"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p id=\"WithheldCREItemsHeaderStatement\" class=\"HighlightedStatement\">One or more entries have been deliberately withheld from this GP Summary.</p><p id=\"SendTime\">Summary Sent: 11 Oct 2017 09:50</p></div>"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/PractitionerRole/A106D415-2361-4E05-8386-6BBE26D8A050",
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "A106D415-2361-4E05-8386-6BBE26D8A050",
+                "identifier": [
+                    {
+                        "system": "http://fhir.nhs.net/Id/sds-role-profile-id",
+                        "value": "103292576980"
+                    }
+                ],
+                "practitioner": {
+                    "reference": "Practitioner/76FC7363-4422-4872-AB72-E39ACEF23C7E"
+                }
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Practitioner/76FC7363-4422-4872-AB72-E39ACEF23C7E",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "76FC7363-4422-4872-AB72-E39ACEF23C7E",
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                        "value": "103267400988"
+                    }
+                ],
+                "name": [
+                    {
+                        "text": "MICHELLEMrsRADFORD"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "https://int.api.service.nhs.uk/summary-care-record/FHIR/R4/Patient/6B6EF256-F6D2-49DB-A542-A40E7D7B8857",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "6B6EF256-F6D2-49DB-A542-A40E7D7B8857",
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "5900247767"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
* Routine Change

Additional information button was triggered even when only withheld information was present. That is not the desired behaviour and this fixes it so that withheld information will now be ignored.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
