### PR TITLE
Niad 2723 update apim package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -121,8 +121,6 @@ files = [
 
 [package.dependencies]
 frozenlist = ">=1.1.0"
-
-[package.dependencies]
 aiohttp = ">=3.7.3,<4.0.0"
 cryptography = ">=3.3.1,<4.0.0"
 pyjwt = ">=2.0.1,<3.0.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,26 +122,12 @@ files = [
 [package.dependencies]
 frozenlist = ">=1.1.0"
 
-[[package]]
-name = "api-test-utils"
-version = "1.1.11a0"
-description = ""
-optional = false
-python-versions = ">=3.8,<4.0"
-files = [
-    {file = "api_test_utils-1.1.11a0-py3-none-any.whl", hash = "sha256:c7270c43473ff9b3c3d2d9b95d5a4421fc508e6893cd53fb3c985fe48b8b506d"},
-]
-
 [package.dependencies]
 aiohttp = ">=3.7.3,<4.0.0"
 cryptography = ">=3.3.1,<4.0.0"
 pyjwt = ">=2.0.1,<3.0.0"
 pytest = ">=6.1.2,<7.0.0"
 pytest-asyncio = ">=0.14.0,<0.15.0"
-
-[package.source]
-type = "url"
-url = "https://github.com/NHSDigital/apim-test-utils/releases/download/v1.1.11-alpha/api_test_utils-1.1.11a0-py3-none-any.whl"
 
 [[package]]
 name = "appdirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ black = "^20.8b1"
 jinja2 = "^2.11.2"
 pytest = "^6.1.2"
 pytest_check = "^1.0.1"
-api-test-utils = {url = "https://github.com/NHSDigital/apim-test-utils/releases/download/v1.1.11-alpha/api_test_utils-1.1.11a0-py3-none-any.whl"}
 pyjwt = "^2.0.1"
 pytest-rerunfailures = "9.1.1"
 pip-licenses = "^3.5.3"


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Updating the APIM testing package. api-test-utils will get retired on 28th of August 2023, at which point everything relying on it will stop working.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
