### PR TITLE
Allow free text field in AuditEvent endpoint

### DIFF
--- a/tests/non_prod/create_token_int.py
+++ b/tests/non_prod/create_token_int.py
@@ -1,0 +1,40 @@
+import uuid
+import jwt
+import requests
+import time
+
+# This file is used to generate an access token which you can then use on the POSTMAN app-restricted API calls.
+# This file should be added to tests/non_prod
+# Check the path to the pem key is correct.
+# Sub and ISS values need to be the app key.
+# You will need to run the following to make this work.
+# pip3 install PyJWT requests
+
+claims = {
+            "sub": "GLp7y8O5dyeAZo4NJq4yAIGHxgW8i8Pa",
+            "iss": "GLp7y8O5dyeAZo4NJq4yAIGHxgW8i8Pa",
+            "jti": str(uuid.uuid4()),
+            "aud": f"https://int.api.service.nhs.uk/oauth2-mock/token",
+            "exp": int(time.time()) + 300,
+        }
+
+headers = {"kid": "test-3"}
+
+with open(f"/Users/steven.mccullagh/Documents/Projects/NHSD/Keys/int/test-3.pem", "r") as f:
+    private_key = f.read()
+
+encoded_jwt = jwt.encode(
+    claims, private_key, algorithm="RS512", headers=headers
+)
+
+response = requests.post(
+    f"https://int.api.service.nhs.uk/oauth2-mock/token",
+    data={
+        "grant_type": "client_credentials",
+        "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        "client_assertion": encoded_jwt,
+    },
+)
+
+response_json = response.json()
+print(response_json)


### PR DESCRIPTION
## Summary
* :sparkles: New Feature

Adding the ability to add free text to the AuditEvent endpoint with the name of `outcomeDesc`, which can only be set when accessing the SCR in an emergency (subtype 4 or 5), and when present, must have content.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
