### PR TITLE
FLAGSAPI-806 convert any date value 1 to a default date

### DIFF
--- a/docker/service/src/test/java/uk/nhs/adaptors/scr/mappings/from/hl7/XmlToFhirMapperTest.java
+++ b/docker/service/src/test/java/uk/nhs/adaptors/scr/mappings/from/hl7/XmlToFhirMapperTest.java
@@ -37,6 +37,11 @@ public class XmlToFhirMapperTest {
         date = parseDate("2023", InstantType.class);
         assertThat(date.getValueAsString()).isEqualTo("2023");
 
+        // FLAGSAPI-806  
+        date = parseDate("1", InstantType.class);
+        // System.out.println(date.getValueAsString());
+        assertThat(date.getValueAsString()).isEqualTo("1970-01-01T01:00:00.000+01:00");
+
         assertThrows(ScrBaseException.class, () -> {
             parseDate("-2023", InstantType.class);
         });


### PR DESCRIPTION

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Some structured data in SCR records has effectiveTime=1 which fails date validation. 
in this scenario I have populated the date with a default 1970 date.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
